### PR TITLE
Fix exception

### DIFF
--- a/1.21.9/src/main/kotlin/code/blurone/cowardless/v1_21_9/ServerNpc.kt
+++ b/1.21.9/src/main/kotlin/code/blurone/cowardless/v1_21_9/ServerNpc.kt
@@ -52,7 +52,7 @@ class ServerNpc(
 
             val apsleHandlerList = AsyncPlayerSpawnLocationEvent.getHandlerList()
             val oldApsleListeners = apsleHandlerList.registeredListeners
-            for (listener in oldApsleListeners) psleHandlerList.unregister(listener)
+            for (listener in oldApsleListeners) apsleHandlerList.unregister(listener)
 
             val pjeHandlerList = PlayerJoinEvent.getHandlerList()
             val oldPjeListeners = pjeHandlerList.registeredListeners


### PR DESCRIPTION
You were trying to unregister the incorrect handler
```
[16:04:25] [Server thread/WARN]: [CowardlessPaper] Global task for CowardlessPaper v4.0.0-P0 generated an exception
java.lang.IllegalStateException: This listener is already registered to priority HIGHEST
	at org.bukkit.event.HandlerList.register(HandlerList.java:123) ~[purpur-api-1.21.10-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.event.HandlerList.registerAll(HandlerList.java:135) ~[purpur-api-1.21.10-R0.1-SNAPSHOT.jar:?]
	at Cowardless.jar/code.blurone.cowardless.v1_21_9.ServerNpc$Companion.createNpc(ServerNpc.kt:75) ~[Cowardless.jar:?]
	at Cowardless.jar/code.blurone.cowardless.CowardlessPaper.onLeave$lambda$0(CowardlessPaper.kt:269) ~[Cowardless.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:178) ~[purpur-1.21.10.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:36) ~[purpur-1.21.10.jar:?]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1773) ~[purpur-1.21.10.jar:1.21.10-2531-b7b7ba2]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1645) ~[purpur-1.21.10.jar:1.21.10-2531-b7b7ba2]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:467) ~[purpur-1.21.10.jar:1.21.10-2531-b7b7ba2]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1365) ~[purpur-1.21.10.jar:1.21.10-2531-b7b7ba2]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[purpur-1.21.10.jar:1.21.10-2531-b7b7ba2]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```