### PR TITLE
Set a default language and add russian translations

### DIFF
--- a/plugin/src/main/java/code/blurone/cowardless/CowardlessPaper.kt
+++ b/plugin/src/main/java/code/blurone/cowardless/CowardlessPaper.kt
@@ -91,16 +91,26 @@ class CowardlessPaper : JavaPlugin(), Listener {
         }
         val messages = YamlConfiguration.loadConfiguration(file)
         val store = MiniMessageTranslationStore.create(Key.key( "cowardless:messages"))
+
+        val defaultLang = messages.getString("default", "en")
+        messages.getConfigurationSection(defaultLang ?: "en")?.let { defaultSection ->
+            store.registerAll(Locale.ROOT, defaultSection.getKeys(false)) { key ->
+                defaultSection.getString(key)!!
+            }
+        }
+
         val entries = messages.getKeys(false)
         for (entry in entries) {
+            if (entry == "default") continue
+
             val localeSection = messages.getConfigurationSection(entry) ?: continue
             val locales = Locale.getAvailableLocales().filter { locale ->
                 val tag = locale.toLanguageTag()
-                    tag == entry || tag.contains(Regex("^$entry")) && tag !in entries
+                    tag == entry || tag.startsWith(entry) && tag !in entries
             }
             for (locale in locales) {
                 store.registerAll(locale, localeSection.getKeys(false)) { key ->
-                    localeSection.getString(key, "")!!
+                    localeSection.getString(key)!!
                 }
             }
         }

--- a/plugin/src/main/resources/messages.yml
+++ b/plugin/src/main/resources/messages.yml
@@ -1,5 +1,6 @@
 # These messages use MiniMessage for formatting.
 # You can live preview them at https://webui.advntr.dev/
+default: "en"
 en:
   actionbar_seconds: "In combat for <s> seconds"
   actionbar_end: "You're no longer in combat"

--- a/plugin/src/main/resources/messages.yml
+++ b/plugin/src/main/resources/messages.yml
@@ -5,6 +5,10 @@ en:
   actionbar_seconds: "In combat for <s> seconds"
   actionbar_end: "You're no longer in combat"
   chat_coward: "<p> is a COWARD"
+ru:
+  actionbar_seconds: "Ты в битве на <s> секунд"
+  actionbar_end: "Ты больше не в битве"
+  chat_coward: "<p> - ТРУС"
 es:
   actionbar_seconds: "En combate por <s> segundos"
   actionbar_end: "Ya no estás en combate"


### PR DESCRIPTION
If you have your client set as an another language which isn't listed in the `messages.yml`, then it's just going to be the key